### PR TITLE
Remove role version check

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -744,10 +744,6 @@ func (as *authStore) isOpPermitted(userName string, revision uint64, key, rangeE
 		return ErrUserEmpty
 	}
 
-	if revision < as.Revision() {
-		return ErrAuthOldRevision
-	}
-
 	tx := as.be.BatchTx()
 	tx.Lock()
 	defer tx.Unlock()

--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
-	Version           = "3.3.10+git"
+	Version           = "3.3.10+patch"
 	APIVersion        = "unknown"
 
 	// Git SHA Value will be set during build


### PR DESCRIPTION
as long as [this range check](https://github.com/etcd-io/etcd/blob/master/auth/store.go#L901) passes, it should be irrelevant what the role version had been when the session was authenticated.